### PR TITLE
Feat/store

### DIFF
--- a/src/main/java/com/example/elevendash/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/elevendash/domain/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.example.elevendash.domain.store.controller;
 
 import com.example.elevendash.domain.member.entity.Member;
 import com.example.elevendash.domain.store.dto.request.RegisterStoreRequestDto;
+import com.example.elevendash.domain.store.dto.response.DeleteStoreResponseDto;
 import com.example.elevendash.domain.store.dto.response.RegisterStoreResponseDto;
 import com.example.elevendash.domain.store.service.StoreService;
 import com.example.elevendash.global.annotation.LoginMember;
@@ -28,11 +29,30 @@ import org.springframework.web.multipart.MultipartFile;
 public class StoreController {
     private final StoreService storeService;
 
+    /**
+     * 상점 등록 엔드포인트
+     * @param requestDto
+     * @param storeImage
+     * @param loginMember
+     * @return
+     */
     @PostMapping("/register")
-    ResponseEntity<CommonResponse<RegisterStoreResponseDto>> register(@RequestBody @Valid RegisterStoreRequestDto requestDto,
+    ResponseEntity<CommonResponse<RegisterStoreResponseDto>> registerStore(@RequestBody @Valid RegisterStoreRequestDto requestDto,
                                                                      @RequestParam("image") MultipartFile storeImage,
                                                                      @LoginMember Member loginMember) {
         return CommonResponse.success(SuccessCode.SUCCESS_INSERT,storeService.registerStore(loginMember,storeImage ,requestDto));
+    }
+
+    /**
+     * 상점 삭제 엔드포인트
+     * @param storeId
+     * @param loginMember
+     * @return
+     */
+    @DeleteMapping("/{storeId}")
+    ResponseEntity<CommonResponse<DeleteStoreResponseDto>> deleteStore(@PathVariable(name = "storeId") Long storeId,
+                                                                       @LoginMember Member loginMember) {
+        return CommonResponse.success(SuccessCode.SUCCESS_DELETE,storeService.deleteStore(loginMember,storeId));
     }
 
 }

--- a/src/main/java/com/example/elevendash/domain/store/dto/request/RegisterStoreRequestDto.java
+++ b/src/main/java/com/example/elevendash/domain/store/dto/request/RegisterStoreRequestDto.java
@@ -4,6 +4,7 @@ import com.example.elevendash.global.validation.ValidPhoneNumber;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -17,7 +18,8 @@ public class RegisterStoreRequestDto {
     @NotBlank(message = "음식점 이름은 필수입니다")
     @Length(min = 2, max = 50,message = "음식점이름은 2~50글자 입니다")
     private final String storeName;
-
+    
+    @Size(max = 1000, message = "상점 설명은 1000자를 초과할 수 없습니다")
     private final String storeDescription;
 
     @NotNull(message = "시작 시간은 필수입니다")

--- a/src/main/java/com/example/elevendash/domain/store/dto/response/DeleteStoreResponseDto.java
+++ b/src/main/java/com/example/elevendash/domain/store/dto/response/DeleteStoreResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.elevendash.domain.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteStoreResponseDto {
+    private Long storeId;
+}

--- a/src/main/java/com/example/elevendash/domain/store/entity/Store.java
+++ b/src/main/java/com/example/elevendash/domain/store/entity/Store.java
@@ -7,6 +7,7 @@ import com.example.elevendash.domain.order.entity.Order;
 import com.example.elevendash.domain.review.entity.Review;
 import com.example.elevendash.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -52,7 +53,8 @@ public class Store extends BaseTimeEntity {
     @Column(nullable = false) @NotBlank
     private String storePhone;
 
-    @Column(nullable = false) @NotBlank
+    @Column(nullable = false) @NotNull
+    @Min(value = 0)
     private Integer leastAmount;
 
     @Lob

--- a/src/main/java/com/example/elevendash/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/elevendash/domain/store/service/StoreService.java
@@ -66,7 +66,7 @@ public class StoreService {
      */
     private Boolean isValidStoreNumber(Member member,Long LimitNumber) {
         Long storeNumber = storeRepository.countByMemberAndIsDeleted(member, Boolean.FALSE);
-        return !storeNumber.equals(LimitNumber);
+        return storeNumber.equals(LimitNumber);
     }
     /**
      * 오픈 마감시간 검증 메소드
@@ -75,7 +75,7 @@ public class StoreService {
      * @return
      */
     private Boolean isValidBusinessHours(LocalTime openTime, LocalTime closeTime) {
-        return !openTime.isBefore(closeTime);
+        return openTime.isBefore(closeTime);
     }
     /**
      * 임시 파일 변환 메소드

--- a/src/main/java/com/example/elevendash/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/elevendash/domain/store/service/StoreService.java
@@ -2,6 +2,7 @@ package com.example.elevendash.domain.store.service;
 
 import com.example.elevendash.domain.member.entity.Member;
 import com.example.elevendash.domain.store.dto.request.RegisterStoreRequestDto;
+import com.example.elevendash.domain.store.dto.response.DeleteStoreResponseDto;
 import com.example.elevendash.domain.store.dto.response.RegisterStoreResponseDto;
 import com.example.elevendash.domain.store.entity.Store;
 import com.example.elevendash.domain.store.repository.StoreRepository;
@@ -56,6 +57,22 @@ public class StoreService {
                 .build();
         storeRepository.save(savedStore);
         return new RegisterStoreResponseDto(savedStore.getId());
+    }
+
+    @Transactional
+    public DeleteStoreResponseDto deleteStore(Member member, Long storeId) {
+        Optional<Store> deleteStore = storeRepository.findById(storeId);
+        // 상점을 찾지 못한경우 예외
+        if(deleteStore.isEmpty()){
+            throw new BaseException(ErrorCode.NOT_FOUND_STORE);
+        }
+        // 상점의 멤버와 현재 멤버가 일치하지 않은경우 예외
+        if(!deleteStore.get().getMember().equals(member)){
+            throw new BaseException(ErrorCode.NOT_SAME_MEMBER);
+        }
+        // soft delete
+        deleteStore.get().delete();
+        return new DeleteStoreResponseDto(deleteStore.get().getId());
     }
 
     /**

--- a/src/main/java/com/example/elevendash/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/example/elevendash/global/exception/code/ErrorCode.java
@@ -58,10 +58,16 @@ public enum ErrorCode {
     ALREADY_DELETED_USER(HttpStatus.BAD_REQUEST, "이미 삭제된 유저 입니다."),
     NONE_NAME(HttpStatus.BAD_REQUEST, "이름은 필수값입니다."),
     BAD_PROVIDER(HttpStatus.BAD_REQUEST, "소셜로그인은 비밀번호가 없어야하며 providerId가 필수입니다."),
-    BAD_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 통한 회원가입은 비밀번호가 필수입니다.")
+    BAD_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 통한 회원가입은 비밀번호가 필수입니다."),
 
+
+
+    /**
+     * Store
+     */
+    NOT_FOUND_STORE(HttpStatus.NOT_FOUND, "상점 정보를 찾을 수 없습니다."),
+    NOT_SAME_MEMBER(HttpStatus.NOT_ACCEPTABLE, "상점과 멤버정보가 일치하지 않습니다.")
     ;
-
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
상점 삭제 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 매장 삭제를 위한 새로운 API 엔드포인트 추가.
	- 매장 등록 메서드의 이름 변경 (register → registerStore).
	- 매장 삭제 응답을 위한 새로운 데이터 구조 추가 (DeleteStoreResponseDto).

- **버그 수정**
	- 매장 등록 요청의 설명 필드에 최대 길이 제한 추가 (1000자).

- **문서화**
	- 매장 등록 및 삭제 메서드에 대한 문서 주석 추가.

- **기타 변경 사항**
	- 매장 최소 금액 필드의 유효성 검사 수정.
	- 매장 삭제 관련 새로운 오류 코드 추가 (NOT_FOUND_STORE, NOT_SAME_MEMBER).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->